### PR TITLE
feat: 기본 response, ControllerAdvice를 통한 error 응답 처리

### DIFF
--- a/src/main/java/com/example/positiveone/global/controller/ControllerAdvice.java
+++ b/src/main/java/com/example/positiveone/global/controller/ControllerAdvice.java
@@ -1,0 +1,50 @@
+package com.example.positiveone.global.controller;
+
+import com.example.positiveone.global.exception.baseException.BaseException;
+import com.example.positiveone.global.exception.notFound.NotFoundException;
+import com.example.positiveone.global.exception.unAuthorized.UnAuthorizedException;
+import com.example.positiveone.global.response.ErrorResponse;
+import com.example.positiveone.global.response.ResultResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    @ExceptionHandler(BaseException.class)
+    public ResultResponse<ErrorResponse> handleBaseException(BaseException e){
+        return ResultResponse.fail(ErrorResponse.of(e.getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnAuthorizedException.class)
+    public ResultResponse<ErrorResponse> handleUnAuthorizedException(UnAuthorizedException e){
+        return ResultResponse.fail(ErrorResponse.of(e.getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NotFoundException.class)
+    public ResultResponse<ErrorResponse> handleNotFoundException(NotFoundException e){
+        return ResultResponse.fail(ErrorResponse.of(e.getMessage()));
+    }
+
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public ResultResponse<ErrorResponse> handleBaseException(Exception e, HttpServletRequest request){
+        log.error("UnhandledException: {} {} errMessage={}\n",
+                request.getMethod(),
+                request.getRequestURI(),
+                e.getMessage()
+        );
+        return ResultResponse.fail(ErrorResponse.of(e.getMessage()));
+    }
+}

--- a/src/main/java/com/example/positiveone/global/exception/PositiveOneException.java
+++ b/src/main/java/com/example/positiveone/global/exception/PositiveOneException.java
@@ -1,0 +1,13 @@
+package com.example.positiveone.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PositiveOneException extends RuntimeException{
+    private final String message;
+
+    public PositiveOneException(String message) {
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/example/positiveone/global/exception/baseException/BaseException.java
+++ b/src/main/java/com/example/positiveone/global/exception/baseException/BaseException.java
@@ -1,0 +1,11 @@
+package com.example.positiveone.global.exception.baseException;
+
+import com.example.positiveone.global.exception.PositiveOneException;
+import com.example.positiveone.global.response.ErrorCode;
+
+public class BaseException extends PositiveOneException {
+
+    public BaseException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/example/positiveone/global/exception/notFound/NotFoundException.java
+++ b/src/main/java/com/example/positiveone/global/exception/notFound/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.positiveone.global.exception.notFound;
+
+import com.example.positiveone.global.exception.PositiveOneException;
+import com.example.positiveone.global.response.ErrorCode;
+
+public class NotFoundException extends PositiveOneException {
+
+    public NotFoundException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/example/positiveone/global/exception/unAuthorized/UnAuthorizedException.java
+++ b/src/main/java/com/example/positiveone/global/exception/unAuthorized/UnAuthorizedException.java
@@ -1,0 +1,11 @@
+package com.example.positiveone.global.exception.unAuthorized;
+
+import com.example.positiveone.global.exception.PositiveOneException;
+import com.example.positiveone.global.response.ErrorCode;
+
+public class UnAuthorizedException extends PositiveOneException {
+
+    public UnAuthorizedException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/example/positiveone/global/response/ErrorCode.java
+++ b/src/main/java/com/example/positiveone/global/response/ErrorCode.java
@@ -1,0 +1,29 @@
+package com.example.positiveone.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    NOT_FOUND_BOARD("게시글을 찾을 수 없습니다."),
+    NOT_FOUND_MEMBER("사용자를 찾을 수 없습니다."),
+    NOT_FOUND_HEART("좋아요를 취소할 수 없습니다."),
+    ALREADY_HEART_PUSH("좋아요를 이미 눌렀습니다."),
+
+    PLATFORM_INVALID("유효하지 않은 로그인 플랫폼입니다."),
+
+    TOKEN_EXPIRED("유효기간이 만료된 토큰입니다."),
+    TOKEN_INVALID("토큰 값이 올바르지 않습니다."),
+
+    APPLE_CLAIMS_INCORRECT("apple claims 값이 올바르지 않습니다."),
+    APPLE_OAUTH_ENCRYPTION_ERROR("apple oauth 통신 암호화 중 문제가 발생했습니다."),
+    APPLE_IDENTITY_TOKEN_EXPIRED("apple identity token 유효기간이 만료됐습니다."),
+    APPLE_IDENTITY_TOKEN_VALUE_INCORRECT("apple identity token 값이 올바르지 않습니다."),
+    APPLE_PUBLIC_KEY_ERROR("apple public key 생성에 문제가 발생했습니다."),
+    APPLE_IDENTITY_TOKEN_INCORRECT("apple identity token 형식이 올바르지 않습니다."),
+    APPLE_JWT_INCORRECT("apple jwt 값이 올바르지 않습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/example/positiveone/global/response/ErrorResponse.java
+++ b/src/main/java/com/example/positiveone/global/response/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.example.positiveone.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ErrorResponse {
+    private final String message;
+
+    public static ErrorResponse of(String message) {
+        return new ErrorResponse(message);
+    }
+}

--- a/src/main/java/com/example/positiveone/global/response/ResultResponse.java
+++ b/src/main/java/com/example/positiveone/global/response/ResultResponse.java
@@ -1,0 +1,36 @@
+package com.example.positiveone.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResultResponse<T> {
+
+    private boolean success;
+    private T data;
+    private String errorMessage;
+
+
+    private ResultResponse(T data) {
+        this.data = data;
+    }
+
+
+    public static <T> ResultResponse<T> success() {
+        return ResultResponse.<T>builder().success(true).build();
+    }
+
+    public static <T> ResultResponse<T> success(T data) {
+        return ResultResponse.<T>builder().success(true).data(data).build();
+    }
+
+    public static <T> ResultResponse<T> fail(ErrorResponse errorResponse) {
+        return ResultResponse.<T>builder().success(false).errorMessage(errorResponse.getMessage()).build();
+    }
+
+}


### PR DESCRIPTION
<h2> 개요 </h2>

- 프로젝트 내에서 응답 형식
- controllerAdvice를 통한 에러 처리와 응답

<h2> 작업 내용 </h2>

- 모든 응답은 200 status로 보내고 success 필드를 통해 성공 유무 판별하도록 설정했습니다.
- UnAthorized, NotFound exception은 401, 404 status로 설정하여 보내도록 했습니다.
- 커스텀 exception은 모두 positiveOneException을 상속받아 구현하였습니다.
- excetion은 BaseException, UnAthorizedException, NotFoundException으로 구성하였습니다.
- 핸들링 하지 못한 예외는 500 status를 설정하여 log를 남기도록 하였습니다.
- ControllerAdvice를 통해 예외를 응답하여 처리하였습니다.