### PR TITLE
feat: security, filter, authentication setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,12 @@ dependencies {
     implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
     implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
 
+
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+
     runtimeOnly 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/example/positiveone/global/annotation/AuthUser.java
+++ b/src/main/java/com/example/positiveone/global/annotation/AuthUser.java
@@ -1,0 +1,14 @@
+package com.example.positiveone.global.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : email")
+public @interface AuthUser {
+}

--- a/src/main/java/com/example/positiveone/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/positiveone/global/config/SecurityConfig.java
@@ -30,7 +30,6 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("/login/**").permitAll()
                 .antMatchers("/board/all/**").permitAll()
-                .antMatchers("/board/calendar/**").permitAll()
                 .anyRequest().authenticated();
         return http.build();
     }

--- a/src/main/java/com/example/positiveone/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/positiveone/global/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.example.positiveone.global.config;
+
+import com.example.positiveone.global.filter.JwtErrorFilter;
+import com.example.positiveone.global.filter.JwtFilter;
+import com.example.positiveone.global.security.authentication.CustomUserDetailService;
+import com.example.positiveone.global.security.token.JWTProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JWTProvider jwtProvider;
+    private final CustomUserDetailService customUserDetailService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http.csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .addFilterBefore(new JwtErrorFilter(), JwtFilter.class)
+                .addFilter(new JwtFilter(authenticationManager(http.getSharedObject(AuthenticationConfiguration.class))
+                        , jwtProvider, customUserDetailService))
+                .authorizeRequests()
+                .antMatchers("/login/**").permitAll()
+                .antMatchers("/board/all/**").permitAll()
+                .antMatchers("/board/calendar/**").permitAll()
+                .anyRequest().authenticated();
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+}

--- a/src/main/java/com/example/positiveone/global/filter/JwtErrorFilter.java
+++ b/src/main/java/com/example/positiveone/global/filter/JwtErrorFilter.java
@@ -1,0 +1,52 @@
+package com.example.positiveone.global.filter;
+
+import com.example.positiveone.global.exception.unAuthorized.ExpiredTokenException;
+import com.example.positiveone.global.exception.unAuthorized.InvalidTokenException;
+import com.example.positiveone.global.response.ErrorCode;
+import com.example.positiveone.global.response.ErrorResponse;
+import com.example.positiveone.global.response.ResultResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtErrorFilter extends HttpFilter {
+
+    @Override
+    protected void doFilter(HttpServletRequest request,
+                            HttpServletResponse response,
+                            FilterChain chain) throws IOException, ServletException {
+        try {
+            chain.doFilter(request, response);
+        } catch (ExpiredTokenException e) {
+            setErrorResponse(response, ErrorCode.TOKEN_EXPIRED);
+        } catch (InvalidTokenException e){
+            setErrorResponse(response, ErrorCode.TOKEN_INVALID);
+        }
+    }
+
+    private void setErrorResponse(
+            HttpServletResponse response,
+            ErrorCode errorCode
+    ){
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        ResultResponse<ErrorResponse> resultResponse = ResultResponse.fail(ErrorResponse.of(errorCode.getMessage()));
+        try{
+            response.getWriter().println(objectMapper.writeValueAsString(resultResponse));
+        }catch (IOException e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/example/positiveone/global/filter/JwtErrorFilter.java
+++ b/src/main/java/com/example/positiveone/global/filter/JwtErrorFilter.java
@@ -8,7 +8,6 @@ import com.example.positiveone.global.response.ResultResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.FilterChain;
@@ -41,7 +40,7 @@ public class JwtErrorFilter extends HttpFilter {
     ){
         ObjectMapper objectMapper = new ObjectMapper();
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setContentType("application/json;charset=UTF-8");
         ResultResponse<ErrorResponse> resultResponse = ResultResponse.fail(ErrorResponse.of(errorCode.getMessage()));
         try{
             response.getWriter().println(objectMapper.writeValueAsString(resultResponse));

--- a/src/main/java/com/example/positiveone/global/filter/JwtFilter.java
+++ b/src/main/java/com/example/positiveone/global/filter/JwtFilter.java
@@ -1,0 +1,55 @@
+package com.example.positiveone.global.filter;
+
+import com.example.positiveone.global.security.authentication.CustomUserDetailService;
+import com.example.positiveone.global.security.token.JWTProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtFilter extends BasicAuthenticationFilter {
+
+    private final JWTProvider jwtProvider;
+    private final CustomUserDetailService customUserDetailService;
+
+
+    public JwtFilter(AuthenticationManager authenticationManager, JWTProvider jwtProvider, CustomUserDetailService customUserDetailService) {
+        super(authenticationManager);
+        this.jwtProvider = jwtProvider;
+        this.customUserDetailService = customUserDetailService;
+    }
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")){
+            String email = jwtProvider.getPayload(authorizationHeader.substring(7));
+
+            Authentication authentication = getAuthentication(email);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+
+
+    private Authentication getAuthentication(String email){
+        UserDetails userDetails = customUserDetailService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, null);
+    }
+
+}

--- a/src/main/java/com/example/positiveone/global/security/authentication/CustomUserDetailService.java
+++ b/src/main/java/com/example/positiveone/global/security/authentication/CustomUserDetailService.java
@@ -1,0 +1,32 @@
+package com.example.positiveone.global.security.authentication;
+
+import com.example.positiveone.global.exception.notFound.NotFoundMemberException;
+import com.example.positiveone.member.domain.Member;
+import com.example.positiveone.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+
+        Member member = memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new);
+        List<GrantedAuthority> roles = new ArrayList<>();
+        roles.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new MemberContext(member.getEmail(), member.getEmail(), roles);
+
+    }
+}

--- a/src/main/java/com/example/positiveone/global/security/authentication/MemberContext.java
+++ b/src/main/java/com/example/positiveone/global/security/authentication/MemberContext.java
@@ -1,0 +1,16 @@
+package com.example.positiveone.global.security.authentication;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+public class MemberContext extends User {
+    private String email;
+    public MemberContext(String username, String password, Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+        this.email = username;
+    }
+}


### PR DESCRIPTION
<h2> 개요 </h2>

- security 설정
- filter 설정
- authentication 설정


<h2> 작업 내용 </h2>

- 로그인, 캘린더, 모든 게시글 보기 요청은 permitAll() 설정을 통해 로그인 없이도 접근 가능하도록 했습니다.
- 그 외의 나머지 요청은 authenticated()로 설정했습니다.
- jwtfilter를 통해 토큰을 검증하고 Authentication에 저장하였습니다.
- jwtErrorfilter를 통해 jwtfilter에서의 error를 처리하였습니다.
- @AuthenticationPrincipal를 custom annotaion을 만들어 token에서 email 값을 추출하였습니다.