### PR TITLE
feat: apple login 기능 구현

### DIFF
--- a/src/main/java/com/example/positiveone/global/config/FeignClientConfig.java
+++ b/src/main/java/com/example/positiveone/global/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package com.example.positiveone.global.config;
+
+import com.example.positiveone.PositiveOneApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = PositiveOneApplication.class)
+public class FeignClientConfig {
+}

--- a/src/main/java/com/example/positiveone/global/exception/unAuthorized/ExpiredTokenException.java
+++ b/src/main/java/com/example/positiveone/global/exception/unAuthorized/ExpiredTokenException.java
@@ -1,0 +1,14 @@
+package com.example.positiveone.global.exception.unAuthorized;
+
+
+import com.example.positiveone.global.response.ErrorCode;
+
+public class ExpiredTokenException extends UnAuthorizedException {
+    public ExpiredTokenException(){
+        super (ErrorCode.TOKEN_EXPIRED);
+    }
+    public ExpiredTokenException(ErrorCode errorCode){
+        super (errorCode);
+    }
+
+}

--- a/src/main/java/com/example/positiveone/global/exception/unAuthorized/InvalidTokenException.java
+++ b/src/main/java/com/example/positiveone/global/exception/unAuthorized/InvalidTokenException.java
@@ -1,0 +1,15 @@
+package com.example.positiveone.global.exception.unAuthorized;
+
+
+import com.example.positiveone.global.exception.notFound.NotFoundException;
+import com.example.positiveone.global.response.ErrorCode;
+
+public class InvalidTokenException extends UnAuthorizedException {
+    public InvalidTokenException(){
+        super (ErrorCode.TOKEN_INVALID);
+    }
+
+    public InvalidTokenException(ErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/positiveone/global/response/ResultResponse.java
+++ b/src/main/java/com/example/positiveone/global/response/ResultResponse.java
@@ -1,5 +1,6 @@
 package com.example.positiveone.global.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) //null 제외
 public class ResultResponse<T> {
 
     private boolean success;

--- a/src/main/java/com/example/positiveone/global/security/token/JWTProvider.java
+++ b/src/main/java/com/example/positiveone/global/security/token/JWTProvider.java
@@ -1,0 +1,48 @@
+package com.example.positiveone.global.security.token;
+
+import com.example.positiveone.global.exception.unAuthorized.ExpiredTokenException;
+import com.example.positiveone.global.exception.unAuthorized.InvalidTokenException;
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Date;
+
+@Component
+public class JWTProvider {
+    private final String secretKey;
+    private final long tokenValidTime;
+    private final JwtParser jwtParser;
+
+    public JWTProvider(@Value("${jwt.secret-key}") String secretKey,
+                       @Value("${jwt.expire}") long tokenValidTime){
+        this.secretKey = secretKey;
+        this.tokenValidTime = tokenValidTime;
+        this.jwtParser = Jwts.parser().setSigningKey(secretKey);
+    }
+
+    public String createToken(String subject){
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + Duration.ofMinutes(tokenValidTime).toMillis());
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setSubject(subject)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public String getPayload(String token){
+        try{
+            return jwtParser.parseClaimsJws(token).getBody().getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException();
+        } catch (JwtException e) {
+            throw new InvalidTokenException();
+        }
+    }
+
+}

--- a/src/main/java/com/example/positiveone/member/auth/apple/AppleClaimsValidator.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/AppleClaimsValidator.java
@@ -1,0 +1,29 @@
+package com.example.positiveone.member.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleClaimsValidator {
+
+    private String iss;
+    private String clientId;
+
+
+    public AppleClaimsValidator(
+            @Value("${oauth.apple.iss}") String iss,
+            @Value("${oauth.apple.client-id}") String clientId
+    ){
+        this.iss = iss;
+        this.clientId = clientId;
+    }
+
+
+    //- Verify that the iss field contains `https://appleid.apple.com`
+    //- Verify that the aud field is the developer’s client_id
+    public boolean isValid(Claims claims){
+        return claims.getIssuer().contains(iss) &&
+                claims.getAudience().equals(clientId);
+    }
+}

--- a/src/main/java/com/example/positiveone/member/auth/apple/AppleClient.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/AppleClient.java
@@ -1,0 +1,11 @@
+package com.example.positiveone.member.auth.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "apple-auth-keys", url = "https://appleid.apple.com/auth")
+public interface AppleClient {
+
+    @GetMapping("/keys")
+    ApplePublicKeys getApplePublicKeys();
+}

--- a/src/main/java/com/example/positiveone/member/auth/apple/AppleClient.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/AppleClient.java
@@ -1,11 +1,20 @@
 package com.example.positiveone.member.auth.apple;
 
+import com.example.positiveone.member.dto.req.AppleTokenReq;
+import com.example.positiveone.member.dto.res.AppleTokenRes;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
 
 @FeignClient(name = "apple-auth-keys", url = "https://appleid.apple.com/auth")
 public interface AppleClient {
 
     @GetMapping("/keys")
     ApplePublicKeys getApplePublicKeys();
+
+    @PostMapping(value = "/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    AppleTokenRes getToken(AppleTokenReq appleTokenReq);
+
 }

--- a/src/main/java/com/example/positiveone/member/auth/apple/AppleClientSecret.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/AppleClientSecret.java
@@ -1,0 +1,63 @@
+package com.example.positiveone.member.auth.apple;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.security.PrivateKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
+public class AppleClientSecret {
+
+    @Value("${oauth.apple.key-id}")
+    private String keyId;
+    @Value("${oauth.apple.team-id}")
+    private String teamId;
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+    @Value("${oauth.apple.iss}")
+    private String authUrl;
+    @Value("${oauth.apple.key-path}")
+    private String keyPath;
+
+    public String createSecret() {
+        Date expirationDate = Date.from(LocalDateTime.now().plusDays(1)
+                .atZone(ZoneId.systemDefault()).toInstant());
+        return Jwts.builder()
+                .setHeaderParam("kid",keyId)
+                .setHeaderParam("alg", "ES256")
+                .setIssuer(teamId)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(expirationDate)
+                .setAudience(authUrl)
+                .setSubject(clientId)
+                .signWith(SignatureAlgorithm.ES256, getPrivateKey())
+                .compact();
+    }
+
+    private PrivateKey getPrivateKey() {
+        try {
+            ClassPathResource resource = new ClassPathResource(keyPath);
+            String privateKey = new String(FileCopyUtils.copyToByteArray(resource.getInputStream()));
+            Reader pemReader = new StringReader(privateKey);
+            PEMParser pemParser = new PEMParser(pemReader);
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            PrivateKeyInfo object = (PrivateKeyInfo) pemParser.readObject();
+            return converter.getPrivateKey(object);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/example/positiveone/member/auth/apple/AppleJwtParser.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/AppleJwtParser.java
@@ -1,0 +1,48 @@
+package com.example.positiveone.member.auth.apple;
+
+import com.example.positiveone.global.exception.unAuthorized.ExpiredTokenException;
+import com.example.positiveone.global.exception.unAuthorized.InvalidTokenException;
+import com.example.positiveone.global.response.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@Component
+public class AppleJwtParser {
+
+    private static final String IDENTITY_TOKEN_DELIMITER = "\\.";
+    private static final int INDEX=0;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public Map<String, String> parserHeaders(String identityToken){
+        try {
+            String encodedHeader = identityToken.split(IDENTITY_TOKEN_DELIMITER)[INDEX];
+            String decodedHeader = new String(Base64Utils.decodeFromUrlSafeString(encodedHeader));
+            return objectMapper.readValue(decodedHeader, Map.class);
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e){
+            throw new InvalidTokenException(ErrorCode.APPLE_IDENTITY_TOKEN_INCORRECT);
+        }
+    }
+
+
+    //- Verify that the time is earlier than the exp value of the token
+    public Claims parsePublicKeyAndGetClaims(String idToken, PublicKey publicKey){
+        try{
+            return Jwts.parser()
+                    .setSigningKey(publicKey)
+                    .parseClaimsJws(idToken)
+                    .getBody();
+        } catch (ExpiredJwtException e){
+            throw new ExpiredTokenException(ErrorCode.APPLE_IDENTITY_TOKEN_EXPIRED);
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e){
+            throw new InvalidTokenException(ErrorCode.APPLE_IDENTITY_TOKEN_VALUE_INCORRECT);
+        }
+    }
+
+}

--- a/src/main/java/com/example/positiveone/member/auth/apple/AppleOAuthUserProvider.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/AppleOAuthUserProvider.java
@@ -1,0 +1,38 @@
+package com.example.positiveone.member.auth.apple;
+
+import com.example.positiveone.global.exception.unAuthorized.InvalidTokenException;
+import com.example.positiveone.global.response.ErrorCode;
+import com.example.positiveone.member.dto.res.OAuthMemberRes;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AppleOAuthUserProvider {
+
+    private final AppleJwtParser appleJwtParser;
+    private final AppleClient appleClient;
+    private final PublicKeyGenerator publicKeyGenerator;
+    private final AppleClaimsValidator appleClaimsValidator;
+
+    public OAuthMemberRes getAppleMember(String identityToken){
+        Map<String, String> headers = appleJwtParser.parserHeaders(identityToken);
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+
+        PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys);
+
+        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+        validateClaims(claims);
+        return new OAuthMemberRes(claims.getSubject(), claims.get("email", String.class));
+    }
+
+    private void validateClaims(Claims claims){
+        if(!appleClaimsValidator.isValid(claims)){
+            throw new InvalidTokenException(ErrorCode.APPLE_CLAIMS_INCORRECT);
+        }
+    }
+}

--- a/src/main/java/com/example/positiveone/member/auth/apple/ApplePublicKey.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/ApplePublicKey.java
@@ -1,0 +1,20 @@
+package com.example.positiveone.member.auth.apple;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApplePublicKey {
+
+    private String kty;
+    private String kid;
+    private String use;
+    private String alg;
+    private String n;
+    private String e;
+}

--- a/src/main/java/com/example/positiveone/member/auth/apple/ApplePublicKeys.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/ApplePublicKeys.java
@@ -1,0 +1,27 @@
+package com.example.positiveone.member.auth.apple;
+
+import com.example.positiveone.global.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApplePublicKeys {
+
+    private List<ApplePublicKey> keys;
+
+    //- Verify the nonce for the authentication
+    public ApplePublicKey getMatchesKey(String alg, String kid){
+        return this.keys
+                .stream()
+                .filter(k -> k.getAlg().equals(alg) && k.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.APPLE_JWT_INCORRECT.getMessage()));
+    }
+}

--- a/src/main/java/com/example/positiveone/member/auth/apple/AppleToken.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/AppleToken.java
@@ -1,0 +1,30 @@
+package com.example.positiveone.member.auth.apple;
+
+import com.example.positiveone.member.dto.req.AppleTokenReq;
+import com.example.positiveone.member.dto.res.AppleTokenRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AppleToken {
+
+    private final AppleClient appleClient;
+
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+    @Value("${oauth.apple.grant-type}")
+    private String grantType;
+
+
+    public AppleTokenRes getAppleToken(String code, String clientSecret){
+        AppleTokenReq appleTokenReq = AppleTokenReq.builder()
+                .client_id(clientId)
+                .client_secret(clientSecret)
+                .code(code)
+                .grant_type(grantType)
+                .build();
+        return appleClient.getToken(appleTokenReq);
+    }
+}

--- a/src/main/java/com/example/positiveone/member/auth/apple/PublicKeyGenerator.java
+++ b/src/main/java/com/example/positiveone/member/auth/apple/PublicKeyGenerator.java
@@ -1,0 +1,51 @@
+package com.example.positiveone.member.auth.apple;
+
+import com.example.positiveone.global.response.ErrorCode;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Map;
+
+/*
+    Base64: '+','/' 사용
+    Base64UrlSafe: '-', '_' 사용
+ */
+@Component
+public class PublicKeyGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+
+    //    //Verify the JWS E256 signature using the server’s public key
+    public PublicKey generatePublicKey(Map<String, String> headers, ApplePublicKeys applePublicKeys){
+        ApplePublicKey applePublicKey =
+                applePublicKeys.getMatchesKey(headers.get(SIGN_ALGORITHM_HEADER_KEY), headers.get(KEY_ID_HEADER_KEY));
+        return generatePublicKeyWithApplePublicKey(applePublicKey);
+    }
+
+    private PublicKey generatePublicKeyWithApplePublicKey(ApplePublicKey publicKey){
+        byte[] nBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getN());
+        byte[] eBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getE());
+
+        BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try{
+            KeyFactory keyFactory = KeyFactory.getInstance(publicKey.getKty());
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception){
+            throw new IllegalArgumentException(ErrorCode.APPLE_PUBLIC_KEY_ERROR.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/example/positiveone/member/controller/AuthController.java
+++ b/src/main/java/com/example/positiveone/member/controller/AuthController.java
@@ -1,0 +1,23 @@
+package com.example.positiveone.member.controller;
+
+
+import com.example.positiveone.global.response.ResultResponse;
+import com.example.positiveone.member.dto.req.AppleLoginInfoReq;
+import com.example.positiveone.member.service.LoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/login")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final LoginService loginService;
+
+
+    @PostMapping("/apple")
+    public ResultResponse<?> getBoard(@RequestBody AppleLoginInfoReq authTokenDTO){
+        return ResultResponse.success(loginService.appleLogin(authTokenDTO));
+    }
+
+}

--- a/src/main/java/com/example/positiveone/member/domain/LoginType.java
+++ b/src/main/java/com/example/positiveone/member/domain/LoginType.java
@@ -1,0 +1,17 @@
+package com.example.positiveone.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public enum LoginType {
+
+    APPLE("apple"),
+    POSITIVE_ONE("positiveOne");
+
+    private String value;
+
+}

--- a/src/main/java/com/example/positiveone/member/domain/Member.java
+++ b/src/main/java/com/example/positiveone/member/domain/Member.java
@@ -1,0 +1,44 @@
+package com.example.positiveone.member.domain;
+
+import com.example.positiveone.global.config.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "MEMBER_ID")
+    private Long id;
+
+    private String email;
+    private String name;
+    private int reportCnt;
+
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType;
+
+    private String loginId;
+
+    private String refreshToken;
+
+    public void reportIncrease(){
+        this.reportCnt++;
+    }
+
+    public void deleteMember(Long memberId){
+        this.email = memberId + "@positive.com";
+        this.loginId = String.valueOf(memberId);
+        this.loginType = LoginType.POSITIVE_ONE;
+        this.refreshToken = "none";
+    }
+}

--- a/src/main/java/com/example/positiveone/member/dto/req/AppleLoginInfoReq.java
+++ b/src/main/java/com/example/positiveone/member/dto/req/AppleLoginInfoReq.java
@@ -1,0 +1,15 @@
+package com.example.positiveone.member.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppleLoginInfoReq {
+    private String identityToken;
+    private String authorization_code;
+}

--- a/src/main/java/com/example/positiveone/member/dto/req/AppleTokenReq.java
+++ b/src/main/java/com/example/positiveone/member/dto/req/AppleTokenReq.java
@@ -1,0 +1,18 @@
+package com.example.positiveone.member.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppleTokenReq {
+    private String client_id;
+    private String client_secret;
+    private String code;
+    private String grant_type;
+    private String refresh_token;
+}

--- a/src/main/java/com/example/positiveone/member/dto/res/AppleTokenRes.java
+++ b/src/main/java/com/example/positiveone/member/dto/res/AppleTokenRes.java
@@ -1,0 +1,16 @@
+package com.example.positiveone.member.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppleTokenRes {
+    private String refresh_token;
+    private String access_token;
+    private String token_type;
+}

--- a/src/main/java/com/example/positiveone/member/dto/res/LoginTokenRes.java
+++ b/src/main/java/com/example/positiveone/member/dto/res/LoginTokenRes.java
@@ -1,0 +1,12 @@
+package com.example.positiveone.member.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginTokenRes {
+    private String token;
+}

--- a/src/main/java/com/example/positiveone/member/dto/res/OAuthMemberRes.java
+++ b/src/main/java/com/example/positiveone/member/dto/res/OAuthMemberRes.java
@@ -1,0 +1,15 @@
+package com.example.positiveone.member.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OAuthMemberRes {
+
+    //사용자 고유 식별값
+    private String loginId;
+    private String email;
+}

--- a/src/main/java/com/example/positiveone/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/positiveone/member/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package com.example.positiveone.member.repository;
+
+import com.example.positiveone.member.domain.LoginType;
+import com.example.positiveone.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findMemberByLoginTypeAndLoginId(LoginType LoginType, String LoginId);
+}

--- a/src/main/java/com/example/positiveone/member/service/LoginService.java
+++ b/src/main/java/com/example/positiveone/member/service/LoginService.java
@@ -1,0 +1,66 @@
+package com.example.positiveone.member.service;
+
+import com.example.positiveone.global.security.token.JWTProvider;
+import com.example.positiveone.member.auth.apple.AppleClientSecret;
+import com.example.positiveone.member.auth.apple.AppleToken;
+import com.example.positiveone.member.domain.Member;
+import com.example.positiveone.member.dto.res.OAuthMemberRes;
+import com.example.positiveone.member.auth.apple.AppleOAuthUserProvider;
+import com.example.positiveone.member.domain.LoginType;
+import com.example.positiveone.member.dto.req.AppleLoginInfoReq;
+import com.example.positiveone.member.dto.res.LoginTokenRes;
+import com.example.positiveone.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+    private final MemberRepository memberRepository;
+    private final JWTProvider jwtProvider;
+    private final AppleOAuthUserProvider appleOAuthUserProvider;
+    private final AppleClientSecret appleClientSecret;
+    private final AppleToken appleToken;
+
+    private final String[] happyName = {"건강한 긍정이", "감사한 긍정이", "느긋한 긍정이", "뿌듯한 긍정이",
+            "따뜻한 긍정이", "즐거운 긍정이", "신난 긍정이", "귀여운 긍정이", "친절한 긍정이", "온화한 긍정이",
+            "고요한 긍정이", "힘찬 긍정이", "사랑스러운 긍정이", "싱그러운 긍정이", "생기있는 긍정이", "기쁜 긍정이",
+            "활력 넘치는 긍정이", "화사한 긍정이", "따사로운 긍정이", "만족스런 긍정이", "상쾌한 긍정이", "자유로운 긍정이"};
+    private final Random rand =new Random();
+
+    public LoginTokenRes appleLogin(AppleLoginInfoReq token){
+        OAuthMemberRes appleMember = appleOAuthUserProvider.getAppleMember(token.getIdentityToken());
+        return generateToken(LoginType.APPLE, appleMember.getEmail(), appleMember.getLoginId(), token.getAuthorization_code());
+    }
+
+    private LoginTokenRes generateToken(LoginType loginType, String email, String loginId, String auth_code){
+        Member findMember = memberRepository.findMemberByLoginTypeAndLoginId(loginType, loginId)
+                .orElseGet(() -> memberRepository.save(Member.builder()
+                                                .name(getRandomName())
+                                                .email(email)
+                                                .loginType(loginType)
+                                                .loginId(loginId)
+                                                .refreshToken(getAppleTokenWithNewMember(auth_code))
+                                                .build()));
+        String token = issueToken(findMember);
+        return new LoginTokenRes(token);
+    }
+
+    public String getRandomName(){
+        return happyName[rand.nextInt(happyName.length)];
+    }
+
+    public String issueToken(Member member){
+        return jwtProvider.createToken(member.getEmail());
+    }
+
+    public String getAppleTokenWithNewMember(String code){
+        String clientSecret = appleClientSecret.createSecret();
+        return appleToken.getAppleToken(code, clientSecret).getRefresh_token();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,20 @@
+spring.datasource.url= jdbc:h2:tcp://localhost/~/positiveOne
+spring.datasource.username= sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto= none
 
 
+#jpa logging
+logging.level.org.hibernate.SQL = debug
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
 
 
+#jwt
+jwt.secret-key = positiveOneJWTKey
+jwt.expire= 30
 
+#OAuth
+#Apple
+oauth.apple.iss = https://appleid.apple.com
+oauth.apple.client-id = aud

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,7 @@ jwt.expire= 30
 #Apple
 oauth.apple.iss = https://appleid.apple.com
 oauth.apple.client-id = aud
+oauth.apple.key-id = ASDFGHJKLP
+oauth.apple.team-id = ASDFGHJKLP
+oauth.apple.key-path = static/apple/abc.p8
+oauth.apple.grant-type = authorization_code

--- a/src/test/java/com/example/positiveone/global/security/token/JWTProviderTest.java
+++ b/src/test/java/com/example/positiveone/global/security/token/JWTProviderTest.java
@@ -1,0 +1,107 @@
+package com.example.positiveone.global.security.token;
+
+import com.example.positiveone.global.exception.unAuthorized.ExpiredTokenException;
+import com.example.positiveone.global.exception.unAuthorized.InvalidTokenException;
+import io.jsonwebtoken.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+
+class JWTProviderTest {
+
+    private final String secretKey = "positiveOneKey";
+    private final long tokenValidTime = 30;
+    private final JwtParser jwtParser  = Jwts.parser().setSigningKey(secretKey);
+
+    private final JWTProvider jwtProvider = new JWTProvider(secretKey, tokenValidTime);
+
+
+    @Test
+    @DisplayName("jwt 생성")
+    void createToken(){
+        //given
+        String email = "asd123@gmail.com";
+
+        //when
+        String newToken = jwtProvider.createToken(email);
+        String parseEmail = jwtParser.parseClaimsJws(newToken).getBody().getSubject();
+
+        //then
+        assertEquals(email, parseEmail);
+    }
+
+
+    @Test
+    @DisplayName("jwt에서 email 추출")
+    void getEmailByJWt(){
+
+        //given
+        String email = "asd123@gmail.com";
+        String newToken = jwtProvider.createToken(email);
+
+
+        //when
+        String parseEmail = jwtProvider.getPayload(newToken);
+
+
+        //then
+        assertEquals(email, parseEmail);
+    }
+
+
+    @Test
+    @DisplayName("만료된 jwt")
+    void expiredJWT(){
+
+        //given
+        String subject = "asd123@gmail.com";
+
+        //when
+        Date now = new Date();
+        String newToken = Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setSubject(subject)
+                .setIssuedAt(now)
+                .setExpiration(now)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+
+        //then
+        assertThrows(ExpiredTokenException.class,
+                     () -> jwtProvider.getPayload(newToken));
+
+    }
+
+
+
+    @Test
+    @DisplayName("유효하지 않은 jwt")
+    void invalidJWT(){
+
+        //given
+        String subject = "asd123@gmail.com";
+
+        //when
+        Date now = new Date();
+        String newToken = Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setSubject(subject)
+                .setIssuedAt(now)
+                .setExpiration(now)
+                .signWith(SignatureAlgorithm.HS256, "jkkl")
+                .compact();
+
+
+        //then
+        assertThrows(InvalidTokenException.class,
+                () -> jwtProvider.getPayload(newToken));
+
+    }
+
+}

--- a/src/test/java/com/example/positiveone/member/auth/AppleClientTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/AppleClientTest.java
@@ -11,7 +11,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.List;
 import java.util.Objects;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 @SpringBootTest
 class AppleClientTest {
@@ -28,7 +29,7 @@ class AppleClientTest {
         boolean isKeysNonNull = keys.stream()
                 .allMatch(this::isAllNotNull);
 
-        assertThat(isKeysNonNull).isTrue();
+        assertTrue(isKeysNonNull);
     }
     private boolean isAllNotNull(ApplePublicKey applePublicKey){
         return Objects.nonNull(applePublicKey.getKty()) && Objects.nonNull(applePublicKey.getKid()) &&

--- a/src/test/java/com/example/positiveone/member/auth/AppleClientTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/AppleClientTest.java
@@ -1,0 +1,40 @@
+package com.example.positiveone.member.auth;
+
+import com.example.positiveone.member.auth.apple.AppleClient;
+import com.example.positiveone.member.auth.apple.ApplePublicKey;
+import com.example.positiveone.member.auth.apple.ApplePublicKeys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class AppleClientTest {
+
+    @Autowired
+    private AppleClient appleClient;
+
+    @Test
+    @DisplayName("apple auth keys 응답")
+    void getPublicKeys(){
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+        List<ApplePublicKey> keys = applePublicKeys.getKeys();
+
+        boolean isKeysNonNull = keys.stream()
+                .allMatch(this::isAllNotNull);
+
+        assertThat(isKeysNonNull).isTrue();
+    }
+    private boolean isAllNotNull(ApplePublicKey applePublicKey){
+        return Objects.nonNull(applePublicKey.getKty()) && Objects.nonNull(applePublicKey.getKid()) &&
+                Objects.nonNull(applePublicKey.getUse()) && Objects.nonNull(applePublicKey.getAlg()) &&
+                Objects.nonNull(applePublicKey.getN()) && Objects.nonNull(applePublicKey.getE());
+    }
+    
+
+}

--- a/src/test/java/com/example/positiveone/member/auth/apple/AppleClaimsValidatorTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/apple/AppleClaimsValidatorTest.java
@@ -1,0 +1,42 @@
+package com.example.positiveone.member.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppleClaimsValidatorTest {
+
+    private static final String ISS = "iss";
+    private static final String CLIENT_ID = "aud";
+
+    private final AppleClaimsValidator appleClaimsValidator = new AppleClaimsValidator(ISS, CLIENT_ID);
+
+    @Test
+    @DisplayName("claims 검증")
+    void isValid(){
+
+        Claims claims = Jwts.claims()
+                .setIssuer(ISS)
+                .setAudience(CLIENT_ID);
+
+
+        assertThat(appleClaimsValidator.isValid(claims)).isTrue();
+    }
+
+
+    @Test
+    @DisplayName("invalid claims exception")
+    void isInvalid(){
+
+        Claims claims = Jwts.claims()
+                .setIssuer("invalid")
+                .setAudience("invalid");
+
+
+        assertThat(appleClaimsValidator.isValid(claims)).isFalse();
+    }
+}

--- a/src/test/java/com/example/positiveone/member/auth/apple/AppleClaimsValidatorTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/apple/AppleClaimsValidatorTest.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 class AppleClaimsValidatorTest {
 
@@ -24,7 +25,7 @@ class AppleClaimsValidatorTest {
                 .setAudience(CLIENT_ID);
 
 
-        assertThat(appleClaimsValidator.isValid(claims)).isTrue();
+        assertTrue(appleClaimsValidator.isValid(claims));
     }
 
 
@@ -37,6 +38,6 @@ class AppleClaimsValidatorTest {
                 .setAudience("invalid");
 
 
-        assertThat(appleClaimsValidator.isValid(claims)).isFalse();
+        assertFalse(appleClaimsValidator.isValid(claims));
     }
 }

--- a/src/test/java/com/example/positiveone/member/auth/apple/AppleJwtParserTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/apple/AppleJwtParserTest.java
@@ -1,0 +1,124 @@
+package com.example.positiveone.member.auth.apple;
+
+import com.example.positiveone.global.exception.unAuthorized.ExpiredTokenException;
+import com.example.positiveone.global.exception.unAuthorized.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.security.*;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AppleJwtParserTest {
+
+    AppleJwtParser appleJwtParser = new AppleJwtParser();
+
+    @Test
+    @DisplayName("identity token으로 헤더 파싱")
+    void parseHeaders() throws NoSuchAlgorithmException {
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "YuyXoY")
+                .claim("id", "1234")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime()+ 60 *60 *24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+
+        Map<String, String> headers = appleJwtParser.parserHeaders(identityToken);
+
+
+        assertThat(headers.get("kid")).isEqualTo("YuyXoY");
+        assertThat(headers.get("alg")).isEqualTo("RS256");
+    }
+
+
+    @Test
+    @DisplayName("올바르지 않은 identity token exception")
+    void parseHeadersWithInvalidToken(){
+        assertThatThrownBy(() -> appleJwtParser.parserHeaders("invalidToken"))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+
+    @Test
+    @DisplayName("identity에서 claims 추출")
+    void parseIdentityTokenAndGetClaims() throws NoSuchAlgorithmException {
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        PrivateKey privateKey = keyPair.getPrivate();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "YuyXoY")
+                .claim("email", "1234@gmail.com")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime()+ 60 *60 *24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+
+        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+
+
+        assertThat(claims.get("email", String.class)).isEqualTo("1234@gmail.com");
+    }
+
+
+    @Test
+    @DisplayName("expired identity token excpetion")
+    void parseExpiredTokenException() throws NoSuchAlgorithmException {
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        PrivateKey privateKey = keyPair.getPrivate();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "YuyXoY")
+                .claim("email", "1234@gmail.com")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() -1))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        assertThatThrownBy(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey))
+                .isInstanceOf(ExpiredTokenException.class);
+    }
+
+
+
+    @Test
+    @DisplayName("invalid public key exception")
+    void parseInvalidPublicKeyException() throws NoSuchAlgorithmException {
+        Date now = new Date();
+        PrivateKey privateKey = KeyPairGenerator.getInstance("RSA").generateKeyPair().getPrivate();
+        PublicKey differPublicKey = KeyPairGenerator.getInstance("RSA").generateKeyPair().getPublic();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "YuyXoY")
+                .claim("email", "1234@gmail.com")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() -1))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+
+        assertThatThrownBy(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, differPublicKey))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+}

--- a/src/test/java/com/example/positiveone/member/auth/apple/AppleJwtParserTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/apple/AppleJwtParserTest.java
@@ -12,8 +12,9 @@ import java.security.*;
 import java.util.Date;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 
 class AppleJwtParserTest {
 
@@ -40,16 +41,16 @@ class AppleJwtParserTest {
         Map<String, String> headers = appleJwtParser.parserHeaders(identityToken);
 
 
-        assertThat(headers.get("kid")).isEqualTo("YuyXoY");
-        assertThat(headers.get("alg")).isEqualTo("RS256");
+        assertEquals(headers.get("kid"), "YuyXoY");
+        assertEquals(headers.get("alg"), "RS256");
     }
 
 
     @Test
     @DisplayName("올바르지 않은 identity token exception")
     void parseHeadersWithInvalidToken(){
-        assertThatThrownBy(() -> appleJwtParser.parserHeaders("invalidToken"))
-                .isInstanceOf(InvalidTokenException.class);
+        assertThrows(InvalidTokenException.class,
+                ()-> appleJwtParser.parserHeaders("invalidToken"));
     }
 
 
@@ -74,7 +75,8 @@ class AppleJwtParserTest {
         Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
 
 
-        assertThat(claims.get("email", String.class)).isEqualTo("1234@gmail.com");
+        assertEquals(claims.get("email", String.class),"1234@gmail.com");
+
     }
 
 
@@ -95,8 +97,9 @@ class AppleJwtParserTest {
                 .signWith(SignatureAlgorithm.RS256, privateKey)
                 .compact();
 
-        assertThatThrownBy(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey))
-                .isInstanceOf(ExpiredTokenException.class);
+        assertThrows(ExpiredTokenException.class,
+                () -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey));
+
     }
 
 
@@ -118,7 +121,7 @@ class AppleJwtParserTest {
                 .compact();
 
 
-        assertThatThrownBy(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, differPublicKey))
-                .isInstanceOf(InvalidTokenException.class);
+        assertThrows(InvalidTokenException.class,
+                () -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, differPublicKey));
     }
 }

--- a/src/test/java/com/example/positiveone/member/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/apple/AppleOAuthUserProviderTest.java
@@ -1,0 +1,96 @@
+package com.example.positiveone.member.auth.apple;
+
+import com.example.positiveone.global.exception.unAuthorized.InvalidTokenException;
+import com.example.positiveone.member.dto.res.OAuthMemberRes;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.security.*;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest
+class AppleOAuthUserProviderTest {
+
+    @Autowired
+    private AppleOAuthUserProvider appleOAuthUserProvider;
+
+    @MockBean
+    private AppleClient appleClient;
+    @MockBean
+    private PublicKeyGenerator publicKeyGenerator;
+    @MockBean
+    private AppleClaimsValidator appleClaimsValidator;
+
+
+    @Test
+    @DisplayName("apple login 시 login id 반환")
+    void getAppleId() throws NoSuchAlgorithmException {
+        String sub = "12345";
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        PrivateKey privateKey = keyPair.getPrivate();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "YuyXoY")
+                .claim("email", "1234@gmail.com")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(sub)
+                .setExpiration(new Date(now.getTime()+ 60 *60 *24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        when(appleClient.getApplePublicKeys()).thenReturn(mock(ApplePublicKeys.class));
+        when(publicKeyGenerator.generatePublicKey(any(), any())).thenReturn(publicKey);
+        when(appleClaimsValidator.isValid(any())).thenReturn(true);
+
+
+        OAuthMemberRes oAuthMemberRes = appleOAuthUserProvider.getAppleMember(identityToken);
+
+
+        assertThat(oAuthMemberRes.getLoginId()).isEqualTo(sub);
+        assertThat(oAuthMemberRes.getEmail()).isEqualTo("1234@gmail.com");
+    }
+
+
+    @Test
+    @DisplayName("invalid claims exception")
+    void invalidClaims() throws NoSuchAlgorithmException {
+        String sub = "12345";
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        PrivateKey privateKey = keyPair.getPrivate();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "YuyXoY")
+                .claim("email", "1234@gmail.com")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(sub)
+                .setExpiration(new Date(now.getTime()+ 60 *60 *24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        when(appleClient.getApplePublicKeys()).thenReturn(mock(ApplePublicKeys.class));
+        when(publicKeyGenerator.generatePublicKey(any(), any())).thenReturn(publicKey);
+        when(appleClaimsValidator.isValid(any())).thenReturn(false);
+
+
+        assertThatThrownBy(() -> appleOAuthUserProvider.getAppleMember(identityToken))
+                .isInstanceOf(InvalidTokenException.class);
+
+    }
+
+}

--- a/src/test/java/com/example/positiveone/member/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/apple/AppleOAuthUserProviderTest.java
@@ -13,9 +13,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import java.security.*;
 import java.util.Date;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.assertj.core.api.Assertions.assertThat;
 
 
 @SpringBootTest
@@ -59,8 +58,8 @@ class AppleOAuthUserProviderTest {
         OAuthMemberRes oAuthMemberRes = appleOAuthUserProvider.getAppleMember(identityToken);
 
 
-        assertThat(oAuthMemberRes.getLoginId()).isEqualTo(sub);
-        assertThat(oAuthMemberRes.getEmail()).isEqualTo("1234@gmail.com");
+        assertEquals(oAuthMemberRes.getLoginId(),sub);
+        assertEquals(oAuthMemberRes.getEmail(),"1234@gmail.com");
     }
 
 
@@ -88,8 +87,8 @@ class AppleOAuthUserProviderTest {
         when(appleClaimsValidator.isValid(any())).thenReturn(false);
 
 
-        assertThatThrownBy(() -> appleOAuthUserProvider.getAppleMember(identityToken))
-                .isInstanceOf(InvalidTokenException.class);
+        assertThrows(InvalidTokenException.class,
+                () -> appleOAuthUserProvider.getAppleMember(identityToken));
 
     }
 

--- a/src/test/java/com/example/positiveone/member/auth/apple/ApplePublicKeysTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/apple/ApplePublicKeysTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ApplePublicKeysTest {
 
@@ -17,7 +16,7 @@ class ApplePublicKeysTest {
 
         ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(applePublicKey));
 
-        assertThat(applePublicKeys.getMatchesKey("alg", "kid"));
+        assertEquals(applePublicKeys.getMatchesKey("alg", "kid"), applePublicKey);
     }
 
 
@@ -28,7 +27,7 @@ class ApplePublicKeysTest {
 
         ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(applePublicKey));
 
-        assertThatThrownBy(() -> applePublicKeys.getMatchesKey("invalid", "invalid"))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThrows(IllegalArgumentException.class,
+                () -> applePublicKeys.getMatchesKey("invalid", "invalid"));
     }
 }

--- a/src/test/java/com/example/positiveone/member/auth/apple/ApplePublicKeysTest.java
+++ b/src/test/java/com/example/positiveone/member/auth/apple/ApplePublicKeysTest.java
@@ -1,0 +1,34 @@
+package com.example.positiveone.member.auth.apple;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApplePublicKeysTest {
+
+    @Test
+    @DisplayName("alg, kid 값을 통해 apple public key 반환")
+    void getMatcheKey(){
+        ApplePublicKey applePublicKey = new ApplePublicKey("kty", "kid", "use", "alg", "n", "e");
+
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(applePublicKey));
+
+        assertThat(applePublicKeys.getMatchesKey("alg", "kid"));
+    }
+
+
+    @Test
+    @DisplayName("alg, kid 값이 일치하는 것이 없다면 exception")
+    void getMatcheInvalidKey(){
+        ApplePublicKey applePublicKey = new ApplePublicKey("kty", "kid", "use", "alg", "n", "e");
+
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(applePublicKey));
+
+        assertThatThrownBy(() -> applePublicKeys.getMatchesKey("invalid", "invalid"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/example/positiveone/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/positiveone/member/controller/AuthControllerTest.java
@@ -1,0 +1,58 @@
+package com.example.positiveone.member.controller;
+
+import com.example.positiveone.global.response.ResultResponse;
+import com.example.positiveone.member.dto.req.AppleLoginInfoReq;
+import com.example.positiveone.member.dto.res.LoginTokenRes;
+import com.example.positiveone.member.service.LoginService;
+import com.jayway.jsonpath.JsonPath;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthControllerTest {
+
+    @MockBean
+    private LoginService loginService;
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUP() {
+        RestAssured.port = port;
+    }
+
+
+    @Test
+    @DisplayName("apple login success")
+    void loginAppleSuccess(){
+
+        AppleLoginInfoReq appleLoginInfoReq = new AppleLoginInfoReq("id_token", "auth_code");
+        LoginTokenRes oauthRes = new LoginTokenRes("123456789");
+
+        when(loginService.appleLogin(any())).thenReturn(oauthRes);
+        ResultResponse<?> res = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(appleLoginInfoReq)
+                .when().post("/login/apple")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(ResultResponse.class);
+
+
+        String token = JsonPath.parse(res.getData()).read("$.token");
+        assertEquals(token, oauthRes.getToken());
+    }
+}

--- a/src/test/java/com/example/positiveone/member/service/LoginServiceTest.java
+++ b/src/test/java/com/example/positiveone/member/service/LoginServiceTest.java
@@ -1,0 +1,127 @@
+package com.example.positiveone.member.service;
+
+import com.example.positiveone.member.auth.apple.AppleClientSecret;
+import com.example.positiveone.member.auth.apple.AppleOAuthUserProvider;
+import com.example.positiveone.member.auth.apple.AppleToken;
+import com.example.positiveone.member.domain.Member;
+import com.example.positiveone.member.dto.req.AppleLoginInfoReq;
+import com.example.positiveone.member.dto.res.AppleTokenRes;
+import com.example.positiveone.member.dto.res.LoginTokenRes;
+import com.example.positiveone.member.dto.res.OAuthMemberRes;
+import com.example.positiveone.member.repository.MemberRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.security.*;
+import java.util.Date;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class LoginServiceTest {
+
+    @Autowired
+    LoginService loginService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+    @MockBean
+    private AppleOAuthUserProvider appleOAuthUserProvider;
+    @MockBean
+    private AppleToken appleToken;
+    @MockBean
+    private AppleClientSecret appleClientSecret;
+
+    private String identityToken;
+
+
+    @BeforeEach
+    void setUp() throws NoSuchAlgorithmException {
+        String sub = "12345";
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        identityToken = Jwts.builder()
+                .setHeaderParam("kid", "YuyXoY")
+                .claim("email", "1234@gmail.com")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(sub)
+                .setExpiration(new Date(now.getTime()+ 60 *60 *24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+    }
+
+
+    @Test
+    @DisplayName("등록된 회원 apple login 성공 시 token 반환")
+    void getTokenWithSignInMember() {
+
+        //given
+        AppleLoginInfoReq appleLoginInfoReq = AppleLoginInfoReq.builder()
+                .identityToken(identityToken)
+                .build();
+
+        Member member = Member.builder()
+                .email("1234@gmail.com")
+                .build();
+
+        when(appleOAuthUserProvider.getAppleMember(any()))
+                .thenReturn(mock(OAuthMemberRes.class));
+        when(memberRepository.findMemberByLoginTypeAndLoginId(any(), any()))
+                .thenReturn(java.util.Optional.ofNullable(member));
+
+
+        //when
+       LoginTokenRes loginTokenRes = loginService.appleLogin(appleLoginInfoReq);
+
+
+       //then
+        assertInstanceOf(String.class, loginTokenRes.getToken());
+    }
+
+
+
+    @Test
+    @DisplayName("등록되지 않은 회원 apple login 성공 시 token 반환")
+    void getTokenWithSignInNoMember() {
+
+        //given
+        String authCode= "auth_code";
+        AppleLoginInfoReq appleLoginInfoReq = AppleLoginInfoReq.builder()
+                .identityToken(identityToken)
+                .authorization_code(authCode)
+                .build();
+
+        Member member = Member.builder()
+                .email("aa123@gmail.com")
+                .build();
+        String token = "aaa";
+
+        when(appleOAuthUserProvider.getAppleMember(any()))
+                .thenReturn(mock(OAuthMemberRes.class));
+        when(memberRepository.save(any())).thenReturn(member);
+
+        when(appleClientSecret.getPrivateKey()).thenReturn(mock(PrivateKey.class));
+        when(appleClientSecret.createSecret()).thenReturn(token);
+        when(appleToken.getAppleToken(authCode, token))
+                .thenReturn(mock(AppleTokenRes.class));
+
+
+        //when
+        LoginTokenRes loginTokenRes = loginService.appleLogin(appleLoginInfoReq);
+
+
+        //then
+        assertInstanceOf(String.class, loginTokenRes.getToken());
+    }
+
+}


### PR DESCRIPTION
<h2> 개요 </h2>

- feignClient를 통해 apple login 기능을 구현했습니다.

<h2> 작업 내용 </h2>

- feignClient 설정
- feignClient를 통해 apple public key 생성
- 로그인 성공 후 positive-one에서 사용되는 jwt 발급